### PR TITLE
cntlm::listen becomes an Array

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -15,7 +15,8 @@ cntlm::cntlm_passnt: ~
 cntlm::cntlm_passntlmv2: ~
 cntlm::cntlm_workstation: ~
 cntlm::cntlm_noproxy: 'localhost, 127.0.0.*, 10.*, 192.168.*'
-cntlm::cntlm_listen: '3128'
+cntlm::cntlm_listen: 
+  '3128'
 cntlm::cntlm_socks5proxy: ~
 cntlm::cntlm_socks5user: ~
 cntlm::cntlm_auth: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@
 # @param cntlm_workstation The netbios hostname cntlm will send to the parent proxies. If unset, the value is auto-guessed by cntlm.
 # @param cntlm_proxy A list of parent proxies to use in format ['proxy_ip:proxy_port', ...]
 # @param cntlm_noproxy A comma separated list of addresses that will not be passed through parent proxyies. * and ? wildcards can be used.
-# @param cntlm_listen The port cntlm should listen on. Can also specify a specific interface and port to bind to, using 'ip:port'.
+# @param cntlm_listen The port cntlm should listen on. Can also specify multiple specific interface and port to bind to, using 'ip:port'.
 # @param cntlm_socks5proxy A list of interfaces and ports to bind to for SOCKS5 proxy functionality,  in format ['ip:port', ...]
 # @param cntlm_socks5user A list of username:password pairs for permissioning access to the SOCKS5 proxy. If unset, the SOCKS5 proxy will accept all requests.
 # @param cntlm_auth The authentication mode to use.
@@ -59,7 +59,7 @@ class cntlm (
     Optional[String] $cntlm_workstation,
     Array[String] $cntlm_proxy,
     Optional[String] $cntlm_noproxy,
-    Optional[String] $cntlm_listen,
+    Optional[Array] $cntlm_listen,
     Optional[Array] $cntlm_socks5proxy,
     Optional[Array] $cntlm_socks5user,
     Optional[String] $cntlm_auth,

--- a/templates/cntlm.conf.epp
+++ b/templates/cntlm.conf.epp
@@ -32,7 +32,9 @@ NoProxy	<%= $cntlm::cntlm_noproxy %>
 <% } -%>
 
 <% unless $cntlm::cntlm_listen =~ Undef { -%>
-Listen	<%= $cntlm::cntlm_listen %>
+<% $cntlm::cntlm_listen.each |$listen| { -%>
+Listen	<%= $listen %>
+<% } -%>
 <% } -%>
 
 <% unless $cntlm::cntlm_socks5proxy =~ Undef { -%>


### PR DESCRIPTION
I need cntlm to listen in more than one interface (so Docker can use the proxy) so I made cntlm::listen a Array instead of a String.